### PR TITLE
Fix node 0.8 support

### DIFF
--- a/lib/line-rule.coffee
+++ b/lib/line-rule.coffee
@@ -10,7 +10,7 @@ class LineRule extends Rule
   ###
   fileAsLines: =>
     @file.read(encoding: 'utf8').then((data) ->
-      lines = data.split(/(\r\n|\n|\r)/)
+      lines = String(data).split(/(\r\n|\n|\r)/)
       # right now the capturing group from the regex is every other element in
       # `lines`. Those groups need to be joined with the line before them.
       i = 0

--- a/lib/rules/indent-char.coffee
+++ b/lib/rules/indent-char.coffee
@@ -29,6 +29,6 @@ class IndentChar extends LineRule
   check: Rule::check
 
   infer: ->
-    @file.read(encoding: 'utf8').then((data) -> detectIndent(data))
+    @file.read(encoding: 'utf8').then((data) -> detectIndent(String(data)))
 
 module.exports = IndentChar

--- a/lib/rules/insert-final-newline.coffee
+++ b/lib/rules/insert-final-newline.coffee
@@ -11,7 +11,7 @@ class InsertFinalNewline extends Rule
 
   fix: =>
     @file.read(encoding:'utf8').then((data) =>
-      @file.write(data.replace(@_finalNewline, (match) =>
+      @file.write(String(data).replace(@_finalNewline, (match) =>
         if @setting is false
           ''
         else
@@ -29,7 +29,7 @@ class InsertFinalNewline extends Rule
   infer: =>
     @file.read(encoding:'utf8').then((data) =>
       if data is '' then return true # empty files don't need final newlines
-      finalNewline = data.match(@_finalNewline)
+      finalNewline = String(data).match(@_finalNewline)
       return (finalNewline? and finalNewline[0] isnt '')
     )
 

--- a/test/end-of-line.coffee
+++ b/test/end-of-line.coffee
@@ -41,7 +41,7 @@ describe 'end_of_line rule integration tests', ->
     ).then(
       @rule.infer
     ).done((res) ->
-      res.should.eql('lf')
+      String(res).should.eql('lf')
       done()
     )
 
@@ -63,7 +63,7 @@ describe 'end_of_line rule integration tests', ->
     ).then( =>
       @file.read(encoding: 'utf8')
     ).done((res) ->
-      res.should.eql('line one\r\nline two\r\nline three\r\n')
+      String(res).should.eql('line one\r\nline two\r\nline three\r\n')
       done()
     )
 
@@ -75,7 +75,7 @@ describe 'end_of_line rule integration tests', ->
     ).then( =>
       @file.read(encoding: 'utf8')
     ).done((res) ->
-      res.should.eql('line one\r\nline two\r\nline three\r\n')
+      String(res).should.eql('line one\r\nline two\r\nline three\r\n')
       done()
     )
 
@@ -87,6 +87,6 @@ describe 'end_of_line rule integration tests', ->
     ).then( =>
       @file.read(encoding: 'utf8')
     ).done((res) ->
-      res.should.eql('line one\r\nline two\r\nline three')
+      String(res).should.eql('line one\r\nline two\r\nline three')
       done()
     )

--- a/test/indent-char.coffee
+++ b/test/indent-char.coffee
@@ -39,7 +39,7 @@ describe 'indent_style/indent_size rule integration (spaces)', ->
     ).then( =>
       @file.read(encoding: 'utf8')
     ).done((res) ->
-      res.should.eql('line one\n  line two\n    line three\n')
+      String(res).should.eql('line one\n  line two\n    line three\n')
       done()
     )
 
@@ -51,7 +51,7 @@ describe 'indent_style/indent_size rule integration (spaces)', ->
     ).then( =>
       @file.read(encoding: 'utf8')
     ).done((res) ->
-      res.should.eql('line one\n  line two\n    line three\n')
+      String(res).should.eql('line one\n  line two\n    line three\n')
       done()
     )
 
@@ -84,7 +84,7 @@ describe 'indent_style/indent_size rule integration (tabs)', ->
     ).then( =>
       @file.read(encoding: 'utf8')
     ).done((res) ->
-      res.should.eql('line one\n\tline two\n\t\tline three\n')
+      String(res).should.eql('line one\n\tline two\n\t\tline three\n')
       done()
     )
 
@@ -96,6 +96,6 @@ describe 'indent_style/indent_size rule integration (tabs)', ->
     ).then( =>
       @file.read(encoding: 'utf8')
     ).done((res) ->
-      res.should.eql('line one\n\tline two\n\t\tline three\n')
+      String(res).should.eql('line one\n\tline two\n\t\tline three\n')
       done()
     )

--- a/test/insert-final-newline.coffee
+++ b/test/insert-final-newline.coffee
@@ -42,7 +42,7 @@ describe 'insert_final_newline rule integration (true)', ->
     ).then( =>
       @file.read(encoding: 'utf8')
     ).done((res) ->
-      res.should.eql('line\n')
+      String(res).should.eql('line\n')
       done()
     )
 
@@ -54,7 +54,7 @@ describe 'insert_final_newline rule integration (true)', ->
     ).then( =>
       @file.read(encoding: 'utf8')
     ).done((res) ->
-      res.should.eql('line\n')
+      String(res).should.eql('line\n')
       done()
     )
 
@@ -87,7 +87,7 @@ describe 'insert_final_newline rule integration (false)', ->
     ).then( =>
       @file.read(encoding: 'utf8')
     ).done((res) ->
-      res.should.eql('line')
+      String(res).should.eql('line')
       done()
     )
 
@@ -99,6 +99,6 @@ describe 'insert_final_newline rule integration (false)', ->
     ).then( =>
       @file.read(encoding: 'utf8')
     ).done((res) ->
-      res.should.eql('line')
+      String(res).should.eql('line')
       done()
     )

--- a/test/trim-trailing-whitespace.coffee
+++ b/test/trim-trailing-whitespace.coffee
@@ -79,7 +79,7 @@ describe 'trim_trailing_whitespace rule integration (true)', ->
     ).then( =>
       @file.read(encoding: 'utf8')
     ).done((res) ->
-      res.should.eql('line one\nline two\n')
+      String(res).should.eql('line one\nline two\n')
       done()
     )
 
@@ -91,6 +91,6 @@ describe 'trim_trailing_whitespace rule integration (true)', ->
     ).then( =>
       @file.read(encoding: 'utf8')
     ).done((res) ->
-      res.should.eql('line one\nline two\n')
+      String(res).should.eql('line one\nline two\n')
       done()
     )


### PR DESCRIPTION
In node 0.8, fs.read is a Buffer, not a String.

This commit ensures that if it's a Buffer, it's toString'd properly.
