### PR TITLE
glob support

### DIFF
--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -1,4 +1,6 @@
 path = require 'path'
+glob = require('glob').sync
+
 packageInfo = require(path.join(__dirname, '../package.json'))
 ArgumentParser = require('argparse').ArgumentParser
 {check, fix, infer} = require './index'
@@ -53,6 +55,8 @@ fixCommand.addArgument(
 )
 
 argv = argparser.parseArgs()
+
+argv.files = Array::concat.apply [], (argv.files.map (f) -> glob f)
 
 if argv.action is 'check'
   check(argv.files)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "detect-indent": "^3.0.1",
     "editorconfig": "^0.12.1",
     "fobject": "0.0.3",
+    "glob": "^5.0.1",
     "graceful-fs": "^3.0.4",
     "lodash": "^2.4.1",
     "require-tree": "^0.3.3",


### PR DESCRIPTION
In contrast to Unix shells the Windows `cmd` is unable to handle glob patterns, this is awkward, especially within plattform independent npm scripts:
```json
  "scripts": {
    "test": "editorconfig-tools check package.json src/a.js src/util/b.js…"
  },
  …
}
```
If you are interested in this PR, but want more information about the `node-glob` project I've used, please visit the [node-glob website](https://github.com/isaacs/node-glob#glob).

(In addition, glob support would also alleviate #2)