### PR TITLE
Update dependencies and lodash methods

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -31,11 +31,11 @@ check = (files) ->
       )
 
   W.all(promises).done((res) ->
-    files = _.uniq _.pluck(res, 'file')
+    files = _.uniq _.map(res, 'file')
     for file in files
-      matches = _.where res, file: file
+      matches = _.filter res, file: file
       verbose = true
-      if verbose or _.compact(_.pluck(matches, 'error')).length > 0
+      if verbose or _.compact(_.map(matches, 'error')).length > 0
         for match in matches
           if match.error?
             exitCode = 1
@@ -143,7 +143,7 @@ infer = (files) ->
 
     groups = _.groupBy(filteredResults, 'rule')
     for property, group of groups
-      distributionOfValues = _.pairs _.countBy _.pluck(group, 'res'), (x) -> x
+      distributionOfValues = _.toPairs _.countBy _.map(group, 'res'), (x) -> x
       sortedValues = _.sortBy distributionOfValues, (x) -> -x[1]
 
       # most common value gets to be global
@@ -152,7 +152,7 @@ infer = (files) ->
 
       # the rest are given a selector based on what files they hit
       for value in sortedValues[1..]
-        files = _.pluck _.where(group, res: value[0]), 'file'
+        files = _.map _.filter(group, res: value[0]), 'file'
         selector = "[{#{files.join(',')}}]"
         rules[selector] ?= []
         rules[selector].push([property, value[0]])

--- a/package.json
+++ b/package.json
@@ -10,19 +10,19 @@
     "url": "https://github.com/slang800/editorconfig-tools/issues"
   },
   "dependencies": {
-    "argparse": "^0.1.15",
-    "detect-indent": "^3.0.1",
+    "argparse": "^1.0.7",
+    "detect-indent": "^4.0.0",
     "editorconfig": "^0.13.2",
-    "fobject": "0.0.3",
-    "graceful-fs": "^3.0.4",
-    "lodash": "^2.4.1",
-    "require-tree": "^0.3.3",
+    "fobject": "0.0.4",
+    "graceful-fs": "^4.1.5",
+    "lodash": "^4.14.0",
+    "require-tree": "^1.1.1",
     "when": "^3.1.0"
   },
   "devDependencies": {
     "coffee-script": "^1.10.0",
     "mocha": "^2.0.1",
-    "should": "^4.1.0"
+    "should": "^10.0.0"
   },
   "keywords": [
     "code-quality",


### PR DESCRIPTION
Update dependencies and lodash 4.x methods to suppress following warning messages.

```
❯ editorconfig-tools infer *
(node:5505) fs: re-evaluating native module sources is not supported. If you are using the graceful-fs module, please update it to a more recent version.
[*]
end_of_line = lf
indent_style = space
```
