### PR TITLE
Turn off verbose warnings by default

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -34,7 +34,7 @@ check = (files) ->
     files = _.uniq _.map(res, 'file')
     for file in files
       matches = _.filter res, file: file
-      verbose = true
+      verbose = false
       if verbose or _.compact(_.map(matches, 'error')).length > 0
         for match in matches
           if match.error?


### PR DESCRIPTION
Default verbosity to off (only errors), which helps when using this with automated tools such as Overcommit.